### PR TITLE
Increase analysis range to 1200 frames + extra improvements

### DIFF
--- a/trdrop/headers/cpp_interface/frameratemodel.h
+++ b/trdrop/headers/cpp_interface/frameratemodel.h
@@ -10,10 +10,10 @@ class FramerateModel
 {
 //! constructors
 public:
-    //! saving the history for at most 180 ticks as we restrict this in the GUI
+    //! saving the history for at most 1200 ticks as we restrict this in the GUI
     FramerateModel()
         : _max_video_count(3)
-        , _max_history_ticks(180)
+        , _max_history_ticks(1200)
     {
         _init_member();
     }

--- a/trdrop/headers/cpp_interface/framerateoptions.h
+++ b/trdrop/headers/cpp_interface/framerateoptions.h
@@ -59,6 +59,14 @@ public:
         painter->setPen(fps_plot_color.color());
         painter->setFont(displayed_text_font);
         painter->drawText(x, y, _get_full_text(frame_index));
+        // draw text in white
+        // todo(illusion): find a better way to do this
+        // we are drawing the text on top
+        // there are small artifacts from the text drawn before this one.
+        QColor white_color = QColor(255, 255, 255);
+        painter->setPen(white_color);
+        painter->setFont(displayed_text_font);
+        painter->drawText(x, y, displayed_text.value());
     }
 
 // methods

--- a/trdrop/headers/cpp_interface/framerateplot.h
+++ b/trdrop/headers/cpp_interface/framerateplot.h
@@ -215,6 +215,26 @@ private:
         painter->setPen(_plot_text_color);
         painter->drawText(x_pos, y_pos, framerate_analysis_range_text);
     }
+    //! draws a vertical center line
+    void _draw_center_line(QPainter * painter)
+    {
+        const int y_init_pos = _plot_outline.y();
+        const int x_init_pos = _plot_outline.x() + _plot_outline.width() / 2;
+
+        const int y_bottom_padding = _plot_outline.height() / 80;
+
+        const int x_pos = x_init_pos;
+        const int y_pos = y_init_pos + y_bottom_padding;
+        // define vertical line
+        QPoint top_line_point(x_pos, y_pos);
+        QPoint bottom_line_point(x_pos, y_pos + _plot_outline.height() * 0.98);
+        // draw "shadow"
+        painter->setPen(_get_centerline_shadow_pen());
+        painter->drawLine(top_line_point, bottom_line_point);
+        // draw white line
+        painter->setPen(_get_centerline_pen());
+        painter->drawLine(top_line_point, bottom_line_point);
+    }
     //! draws all framerates graphs options are enabled
     void _draw_framerates(QPainter * painter)
     {
@@ -314,26 +334,6 @@ private:
         painter->setPen(_get_outerline_pen());
         painter->setBrush(brush);
         painter->drawPolygon(triangle);
-    }
-    //! draws a vertical center line
-    void _draw_center_line(QPainter * painter)
-    {
-        const int y_init_pos = _plot_outline.y();
-        const int x_init_pos = _plot_outline.x() + _plot_outline.width() / 2;
-
-        const int y_bottom_padding = _plot_outline.height() / 80;
-
-        const int x_pos = x_init_pos;
-        const int y_pos = y_init_pos + y_bottom_padding;
-        // define vertical line
-        QPoint top_line_point(x_pos, y_pos);
-        QPoint bottom_line_point(x_pos, y_pos + _plot_outline.height() * 0.98);
-        // draw "shadow"
-        painter->setPen(_get_centerline_shadow_pen());
-        painter->drawLine(top_line_point, bottom_line_point);
-        // draw white line
-        painter->setPen(_get_centerline_pen());
-        painter->drawLine(top_line_point, bottom_line_point);
     }
 // methods
 private:

--- a/trdrop/headers/cpp_interface/framerateplot.h
+++ b/trdrop/headers/cpp_interface/framerateplot.h
@@ -28,7 +28,7 @@ public:
         , _plot_text_color(255, 255, 255) // white
         , _text_shadow(41, 41, 41) // dark grey
         , _segment_count(4) // we want to split the plot into 4 bars
-        , _eyecandy_text("FRAMERATE")
+        , _eyecandy_text("Framerate (fps)")
         , _x_axis_prefix_text("ANALYSIS RANGE: ")
     { }
 
@@ -409,13 +409,13 @@ private:
     int _get_font_size()
     {
         QSize current_size = _shared_resolution_model->get_active_size();
-        if      (current_size == QSize(960, 540))   return 13;
-        else if (current_size == QSize(1280, 720))  return 18;
-        else if (current_size == QSize(1600, 900))  return 22;
-        else if (current_size == QSize(1920, 1080)) return 27;
-        else if (current_size == QSize(2048, 1152)) return 30;
-        else if (current_size == QSize(2560, 1440)) return 37;
-        else if (current_size == QSize(3840, 2160)) return 51;
+        if      (current_size == QSize(960, 540))   return 8;
+        else if (current_size == QSize(1280, 720))  return 12;
+        else if (current_size == QSize(1600, 900))  return 15;
+        else if (current_size == QSize(1920, 1080)) return 20;
+        else if (current_size == QSize(2048, 1152)) return 22;
+        else if (current_size == QSize(2560, 1440)) return 29;
+        else if (current_size == QSize(3840, 2160)) return 35;
         qDebug() << "FrameratePlot::_get_font_size() - there is no case for the current resolution(" << current_size << "), this should never happen";
         return 13;
     }
@@ -423,13 +423,13 @@ private:
     int _get_eyecandy_font_size()
     {
         QSize current_size = _shared_resolution_model->get_active_size();
-        if      (current_size == QSize(960, 540))   return 13 + 3;
-        else if (current_size == QSize(1280, 720))  return 18 + 3;
-        else if (current_size == QSize(1600, 900))  return 22 + 3;
-        else if (current_size == QSize(1920, 1080)) return 27 + 3;
-        else if (current_size == QSize(2048, 1152)) return 30 + 3;
-        else if (current_size == QSize(2560, 1440)) return 37 + 3;
-        else if (current_size == QSize(3840, 2160)) return 51 + 12;
+        if      (current_size == QSize(960, 540))   return 8 + 3;
+        else if (current_size == QSize(1280, 720))  return 12 + 3;
+        else if (current_size == QSize(1600, 900))  return 15 + 3;
+        else if (current_size == QSize(1920, 1080)) return 20 + 3;
+        else if (current_size == QSize(2048, 1152)) return 22 + 3;
+        else if (current_size == QSize(2560, 1440)) return 29 + 3;
+        else if (current_size == QSize(3840, 2160)) return 35 + 12;
         qDebug() << "FrameratePlot::_get_eyecandy_font_size() - there is no case for the current resolution(" << current_size << "), this should never happen";
         return 13;
     }

--- a/trdrop/headers/cpp_interface/framerateplot.h
+++ b/trdrop/headers/cpp_interface/framerateplot.h
@@ -191,7 +191,7 @@ private:
     {
         painter->setFont(_get_eyecandy_text_font());
 
-        const uint8_t framerate_analysis_range = (*_shared_general_options_model).get_framerate_range();
+        const int framerate_analysis_range = (*_shared_general_options_model).get_framerate_range();
         const QString framerate_analysis_range_text = _x_axis_prefix_text + QString::number(framerate_analysis_range) + " frames";
 
         const int y_init_pos = _plot_outline.y() + _plot_outline.height();
@@ -230,7 +230,7 @@ private:
         // set pen to the correct color and line width
         painter->setPen(_get_framerate_pen(video_count));
         // how many ticks do we want to display
-        const uint8_t framerate_ticks = _shared_general_options_model->get_framerate_range();
+        const int framerate_ticks = _shared_general_options_model->get_framerate_range();
         // will always be positive, history is fixed in frameratemodel and ticks are restricted by GUI
         const size_t size_difference = framerate_history.size() - framerate_ticks;
         // need the maximums to calculate the position of the point

--- a/trdrop/headers/cpp_interface/framerateplot.h
+++ b/trdrop/headers/cpp_interface/framerateplot.h
@@ -36,7 +36,7 @@ public:
 public:
     //! top left is (0,0), painter has to be pointed to the image by the renderer
     //! order of drawing functions is essential
-    void draw_framerate_plot(QPainter * painter, bool enable_framerate_centering, bool enable_x_axis_text)
+    void draw_framerate_plot(QPainter * painter, bool enable_framerate_centering, bool enable_triangle_centering, bool enable_x_axis_text)
     {
         painter->setRenderHint(QPainter::Antialiasing);
         painter->setRenderHint(QPainter::HighQualityAntialiasing);
@@ -45,8 +45,11 @@ public:
         _draw_plot_inner_lines(painter);
         if (enable_framerate_centering)
         {
-            _draw_center_triangle(painter);
             _draw_center_line(painter);
+        }
+        if (enable_triangle_centering)
+        {
+            _draw_center_triangle(painter);
         }
         _draw_framerates(painter);
         _draw_plot_outline(painter);

--- a/trdrop/headers/cpp_interface/frametimemodel.h
+++ b/trdrop/headers/cpp_interface/frametimemodel.h
@@ -11,10 +11,10 @@ class FrametimeModel
 //! constructors
 public:
     //! holds the frametime information
-    //! saving the history for 180 ticks as we restrict this in the GUI
+    //! saving the history for 1200 ticks as we restrict this in the GUI
     FrametimeModel()
         : _max_video_count(3)
-        , _max_history_ticks(180)
+        , _max_history_ticks(1200)
     {
         _init_member();
     }

--- a/trdrop/headers/cpp_interface/frametimeplot.h
+++ b/trdrop/headers/cpp_interface/frametimeplot.h
@@ -27,7 +27,7 @@ public:
         , _plot_text_color(255, 255, 255) // white
         , _text_shadow(41, 41, 41) // dark grey
         , _segment_count(3) // we want to split the plot into 3 bars
-        , _eyecandy_text("FRAMETIME IN MS")
+        , _eyecandy_text("Frametime (ms)")
     { }
 
 // methods
@@ -169,7 +169,7 @@ private:
         const int x_init_pos = _plot_outline.x() + _plot_outline.width();
 
         const int y_bottom_padding = _plot_outline.height() / 10;
-        const int x_right_padding  = static_cast<int>(_plot_outline.width() / 1.45);
+        const int x_right_padding  = static_cast<int>(_plot_outline.width() / 2.55);
 
         const int x_pos = x_init_pos - x_right_padding;
         const int y_pos = y_init_pos - y_bottom_padding;
@@ -338,13 +338,13 @@ private:
     int _get_font_size()
     {
         QSize current_size = _shared_resolution_model->get_active_size();
-        if      (current_size == QSize(960, 540))   return 13;
-        else if (current_size == QSize(1280, 720))  return 18;
-        else if (current_size == QSize(1600, 900))  return 22;
-        else if (current_size == QSize(1920, 1080)) return 27;
-        else if (current_size == QSize(2048, 1152)) return 30;
-        else if (current_size == QSize(2560, 1440)) return 37;
-        else if (current_size == QSize(3840, 2160)) return 51;
+        if      (current_size == QSize(960, 540))   return 8;
+        else if (current_size == QSize(1280, 720))  return 12;
+        else if (current_size == QSize(1600, 900))  return 15;
+        else if (current_size == QSize(1920, 1080)) return 20;
+        else if (current_size == QSize(2048, 1152)) return 22;
+        else if (current_size == QSize(2560, 1440)) return 29;
+        else if (current_size == QSize(3840, 2160)) return 35;
         qDebug() << "FrametimePlot::_get_font_size() - there is no case for the current resolution(" << current_size << "), this should never happen";
         return 13;
     }
@@ -352,13 +352,13 @@ private:
     int _get_eyecandy_font_size()
     {
         QSize current_size = _shared_resolution_model->get_active_size();
-        if      (current_size == QSize(960, 540))   return 13 + 3;
-        else if (current_size == QSize(1280, 720))  return 18 + 3;
-        else if (current_size == QSize(1600, 900))  return 22 + 3;
-        else if (current_size == QSize(1920, 1080)) return 27 + 3;
-        else if (current_size == QSize(2048, 1152)) return 30 + 3;
-        else if (current_size == QSize(2560, 1440)) return 37 + 3;
-        else if (current_size == QSize(3840, 2160)) return 51 + 12;
+        if      (current_size == QSize(960, 540))   return 8 + 3;
+        else if (current_size == QSize(1280, 720))  return 12 + 3;
+        else if (current_size == QSize(1600, 900))  return 15 + 3;
+        else if (current_size == QSize(1920, 1080)) return 20 + 3;
+        else if (current_size == QSize(2048, 1152)) return 22 + 3;
+        else if (current_size == QSize(2560, 1440)) return 29 + 3;
+        else if (current_size == QSize(3840, 2160)) return 35 + 12;
         qDebug() << "FrametimePlot::_get_eyecandy_font_size() - there is no case for the current resolution(" << current_size << "), this should never happen";
         return 13;
     }

--- a/trdrop/headers/cpp_interface/frametimeplot.h
+++ b/trdrop/headers/cpp_interface/frametimeplot.h
@@ -33,13 +33,17 @@ public:
 // methods
 public:
     //! top left is (0,0)
-    void draw_frametime_plot(QPainter * painter)
+    void draw_frametime_plot(QPainter * painter, bool enable_framerate_centering)
     {
         painter->setRenderHint(QPainter::Antialiasing);
         painter->setRenderHint(QPainter::HighQualityAntialiasing);
 
         _set_plot_outline();
         _draw_plot_inner_lines(painter);
+        if (enable_framerate_centering)
+        {
+        _draw_center_line(painter);
+        }
         _draw_frametimes(painter);
         _draw_plot_outline(painter);
         _draw_text(painter);
@@ -222,6 +226,26 @@ private:
             index++;
         });
     }
+    //! draws a vertical center line
+    void _draw_center_line(QPainter * painter)
+    {
+        const int y_init_pos = _plot_outline.y();
+        const int x_init_pos = _plot_outline.x() + _plot_outline.width() / 2;
+
+        const int y_bottom_padding = _plot_outline.height() / 80;
+
+        const int x_pos = x_init_pos;
+        const int y_pos = y_init_pos + y_bottom_padding;
+        // define vertical line
+        QPoint top_line_point(x_pos, y_pos);
+        QPoint bottom_line_point(x_pos, y_pos + _plot_outline.height() * 0.98);
+        // draw "shadow"
+        painter->setPen(_get_centerline_shadow_pen());
+        painter->drawLine(top_line_point, bottom_line_point);
+        // draw white line
+        painter->setPen(_get_centerline_pen());
+        painter->drawLine(top_line_point, bottom_line_point);
+    }
     //! calculates the x,y position of the framerate based on its index and value
     QPoint _to_plot_coords(const double frametime
                          , const double max_frametime
@@ -248,7 +272,27 @@ private:
         QPen pen;
         pen.setWidth(_get_outline_thickness());
         pen.setColor(_plot_outline_color);
-        pen.setJoinStyle(Qt::MiterJoin); // hard counters
+        pen.setJoinStyle(Qt::MiterJoin); // hard corners
+        return pen;
+    }
+    //! resolution adaptive outerline pen
+    QPen _get_centerline_pen()
+    {
+        QPen pen;
+        pen.setWidth(_get_outline_thickness());
+        QColor color = _plot_outline_color;
+        pen.setColor(color);
+        pen.setJoinStyle(Qt::MiterJoin); // hard corners
+        return pen;
+    }
+    //! resolution adaptive outerline pen
+    QPen _get_centerline_shadow_pen()
+    {
+        QPen pen;
+        pen.setWidth(_get_outline_thickness());
+        QColor color = _text_shadow;
+        pen.setColor(color);
+        pen.setJoinStyle(Qt::MiterJoin); // hard corners
         return pen;
     }
     //! resolution adaptive outerline pen

--- a/trdrop/headers/cpp_interface/frametimeplot.h
+++ b/trdrop/headers/cpp_interface/frametimeplot.h
@@ -197,7 +197,7 @@ private:
         // set pen to the correct color and line width
         painter->setPen(_get_frametime_pen(video_index));
         // how many ticks do we want to display
-        const uint8_t frametime_ticks = _shared_general_options_model->get_frametime_range();
+        const int frametime_ticks = _shared_general_options_model->get_frametime_range();
         // will always be positive, history is fixed in frameratemodel and ticks are restrict
         const size_t size_difference = ft_history.size() - frametime_ticks;
         // need the maximums to calculate the position of the point

--- a/trdrop/headers/qml_interface/renderer_qml.h
+++ b/trdrop/headers/qml_interface/renderer_qml.h
@@ -142,7 +142,8 @@ private:
     //! calls the underlying instance to draw the graph
     void _draw_frametime_graph(QPainter & painter)
     {
-        _shared_frametime_plot_instance->draw_frametime_plot(&painter);
+        bool enable_framerate_centering = (*_shared_general_options_model).get_enable_framerate_centering();
+        _shared_frametime_plot_instance->draw_frametime_plot(&painter, enable_framerate_centering);
     }
     //! calls each tearmodel to draw each tear
     void _draw_tears(QPainter & painter)

--- a/trdrop/headers/qml_interface/renderer_qml.h
+++ b/trdrop/headers/qml_interface/renderer_qml.h
@@ -135,8 +135,9 @@ private:
     void _draw_framerate_graph(QPainter & painter)
     {
         bool enable_framerate_centering = (*_shared_general_options_model).get_enable_framerate_centering();
+        bool enable_triangle_centering = (*_shared_general_options_model).get_enable_triangle_centering();
         bool enable_x_axis_text = (*_shared_general_options_model).get_enable_x_axis_text();
-        _shared_framerate_plot_instance->draw_framerate_plot(&painter, enable_framerate_centering, enable_x_axis_text);
+        _shared_framerate_plot_instance->draw_framerate_plot(&painter, enable_framerate_centering, enable_triangle_centering, enable_x_axis_text);
     }
     //! calls the underlying instance to draw the graph
     void _draw_frametime_graph(QPainter & painter)

--- a/trdrop/headers/qml_models/generaloptionsmodel.h
+++ b/trdrop/headers/qml_models/generaloptionsmodel.h
@@ -274,8 +274,8 @@ private:
         _enable_triangle_centering.setTooltip("Displays Triangle Playhead in center of framerate graph.");
         _enable_triangle_centering.setValue(false);
 
-        _enable_framerate_centering.setName("Enable FPS graph centering");
-        _enable_framerate_centering.setTooltip("The center of the framerate plot is now showing the \"current\" framerate, not the right most edge");
+        _enable_framerate_centering.setName("Enable Frame graph centering");
+        _enable_framerate_centering.setTooltip("The center of the framerate and frametime plot is now showing the \"current\" framerate, not the right most edge");
         _enable_framerate_centering.setValue(true);
 
         _enable_x_axis_text.setName("Enable framerate analysis range text");

--- a/trdrop/headers/qml_models/generaloptionsmodel.h
+++ b/trdrop/headers/qml_models/generaloptionsmodel.h
@@ -52,6 +52,9 @@ public:
       , EnableXAxisTextNameRole             = Qt::UserRole + 27
       , EnableXAxisTextTooltipRole          = Qt::UserRole + 28
       , EnableXAxisTextValueRole            = Qt::UserRole + 29
+      , EnableTriangleNameRole              = Qt::UserRole + 30
+      , EnableTriangleTooltipRole           = Qt::UserRole + 31
+      , EnableTriangleValueRole             = Qt::UserRole + 32
     };
 //! methods
 public:
@@ -123,6 +126,12 @@ public:
                 return _enable_framerate_centering.tooltip();
             case EnableFrametimeCenteringValueRole:
                 return _enable_framerate_centering.value();
+            case EnableTriangleNameRole:
+                return _enable_triangle_centering.name();
+            case EnableTriangleTooltipRole:
+                return _enable_triangle_centering.tooltip();
+            case EnableTriangleValueRole:
+                return _enable_triangle_centering.value();
             case EnableXAxisTextNameRole:
                 return _enable_x_axis_text.name();
             case EnableXAxisTextTooltipRole:
@@ -145,6 +154,7 @@ public:
         else if (role == FrametimeRangeValueRole) _frametime_plot_range.setValue(static_cast<int>(value.toUInt()));
         else if (role == FramerateMaxFPSValueRole) _framerate_max_fps.setValue(static_cast<int>(value.toUInt()));
         else if (role == FrametimeMaxMSValueRole) _frametime_max_ms.setValue(static_cast<int>(value.toUInt()));
+        else if (role == EnableTriangleValueRole) _enable_triangle_centering.setValue(value.toBool());
         else if (role == EnableFrametimeCenteringValueRole) _enable_framerate_centering.setValue(value.toBool());
         else if (role == EnableXAxisTextValueRole) _enable_x_axis_text.setValue(value.toBool());
         else return false;
@@ -181,6 +191,8 @@ public:
     //! getter
     int get_frametime_max_ms() { return _frametime_max_ms.value(); }
     //! getter
+    bool get_enable_triangle_centering() { return _enable_triangle_centering.value(); }
+    //! getter
     bool get_enable_framerate_centering() { return _enable_framerate_centering.value(); }
     //! getter
     bool get_enable_x_axis_text() { return _enable_x_axis_text.value(); }
@@ -216,6 +228,9 @@ private:
         _role_names[EnableFrametimeCenteringNameRole]    = "enableFramerateCenteringName";
         _role_names[EnableFrametimeCenteringTooltipRole] = "enableFramerateCenteringTooltip";
         _role_names[EnableFrametimeCenteringValueRole]   = "enableFramerateCenteringValue";
+        _role_names[EnableTriangleNameRole]              = "EnableTriangleName";
+        _role_names[EnableTriangleTooltipRole]           = "EnableTriangleTooltip";
+        _role_names[EnableTriangleValueRole]             = "EnableTriangleValue";
         _role_names[EnableXAxisTextNameRole]             = "enableXAxisTextName";
         _role_names[EnableXAxisTextTooltipRole]          = "enableXAxisTextTooltip";
         _role_names[EnableXAxisTextValueRole]            = "enableXAxisTextValue";
@@ -255,6 +270,10 @@ private:
         _frametime_max_ms.setTooltip("Height of the frametime plot in ms (y-axis)");
         _frametime_max_ms.setValue(100);
 
+        _enable_triangle_centering.setName("Enable Triangle Playhead");
+        _enable_triangle_centering.setTooltip("Displays Triangle Playhead in center of framerate graph.");
+        _enable_triangle_centering.setValue(false);
+
         _enable_framerate_centering.setName("Enable FPS graph centering");
         _enable_framerate_centering.setTooltip("The center of the framerate plot is now showing the \"current\" framerate, not the right most edge");
         _enable_framerate_centering.setValue(true);
@@ -286,6 +305,8 @@ private:
     ValueItem<int> _frametime_max_ms;
     //! essentially a bool
     CheckBoxItem _enable_framerate_centering;
+    //! essentially a bool
+    CheckBoxItem _enable_triangle_centering;
     //! essentially a bool
     CheckBoxItem _enable_x_axis_text;
 };

--- a/trdrop/headers/qml_models/generaloptionsmodel.h
+++ b/trdrop/headers/qml_models/generaloptionsmodel.h
@@ -241,7 +241,7 @@ private:
 
         _framerate_plot_range.setName("Analysis range:");
         _framerate_plot_range.setTooltip("Length of the framerate plot in frames (x-axis)");
-        _framerate_plot_range.setValue(60);
+        _framerate_plot_range.setValue(360);
 
         _framerate_max_fps.setName("Max FPS:");
         _framerate_max_fps.setTooltip("Height of the framerate plot in framerate (y-axis)");
@@ -249,7 +249,7 @@ private:
 
         _frametime_plot_range.setName("Analysis range:");
         _frametime_plot_range.setTooltip("Length of the frametime plot in frames (x-axis)");
-        _frametime_plot_range.setValue(60);
+        _frametime_plot_range.setValue(360);
 
         _frametime_max_ms.setName("Max Frametime:");
         _frametime_max_ms.setTooltip("Height of the frametime plot in ms (y-axis)");
@@ -257,11 +257,11 @@ private:
 
         _enable_framerate_centering.setName("Enable FPS graph centering");
         _enable_framerate_centering.setTooltip("The center of the framerate plot is now showing the \"current\" framerate, not the right most edge");
-        _enable_framerate_centering.setValue(false);
+        _enable_framerate_centering.setValue(true);
 
         _enable_x_axis_text.setName("Enable framerate analysis range text");
         _enable_x_axis_text.setTooltip("Draws the framerate anaylsis range text below the framerate plot");
-        _enable_x_axis_text.setValue(true);
+        _enable_x_axis_text.setValue(false);
     }
 
 //! member

--- a/trdrop/qml/FileWindow.qml
+++ b/trdrop/qml/FileWindow.qml
@@ -74,7 +74,7 @@ Window {
                     FileDialog {
                         id: fileDialog
                         title: "Please choose an uncompressed video"
-                        nameFilters: ["Video files (*.mp4 *.avi *.raw)", "All files (*)"]
+                        nameFilters: ["Video files (*.avi *.mp4 *.mov *.mkv *.raw)", "All files (*)"]
                         visible: false
                         folder: shortcuts.movies
                         onAccepted: {

--- a/trdrop/qml/OptionsWindow.qml
+++ b/trdrop/qml/OptionsWindow.qml
@@ -150,7 +150,7 @@ Window {
                         SpinBox {
                             id: framerateRange
                             from: 30
-                            to: 180
+                            to: 1200
                             stepSize: 10
                             editable: true
                             value: model.framerateRangeValue
@@ -232,7 +232,7 @@ Window {
                         SpinBox {
                             id: frametimeRange
                             from: 30
-                            to: 180
+                            to: 1200
                             stepSize: 10
                             editable: true
                             value: model.frametimeRangeValue

--- a/trdrop/qml/OptionsWindow.qml
+++ b/trdrop/qml/OptionsWindow.qml
@@ -312,6 +312,19 @@ Window {
                                 }
                             }
                         }
+                        Switch {
+                            Layout.columnSpan: 3
+                            text: model.EnableTriangleName
+                            checked: model.EnableTriangleValue
+                            ToolTip.delay: 500
+                            ToolTip.visible: hovered
+                            ToolTip.text: model.EnableTriangleTooltip
+                            action: Action {
+                                onTriggered: {
+                                    model.EnableTriangleValue = !model.EnableTriangleValue;
+                                }
+                            }
+                        }
                         // 9th row
                         Button {
                             Layout.columnSpan: 3

--- a/trdrop/qml/main.qml
+++ b/trdrop/qml/main.qml
@@ -7,10 +7,10 @@ import QtQuick.Controls.Styles 1.4
 
 ApplicationWindow
 {
-    // startup as a fullscreen application
+    // startup as a windowed application
     id: rootWindow
-    minimumWidth: Screen.width
-    minimumHeight: Screen.height
+    minimumWidth: 1280
+    minimumHeight: 720
     visible: true
     // TODO refactor this so the user may choose a light theme
     Material.theme: Material.Dark


### PR DESCRIPTION
The max of 3 seconds in 60 FPS previously was going too quick.

Known issues: frame rate and graph does not start and end with the video. This is an old bug and was less noticeable on 180 frames previously.

Build for testers: https://drive.google.com/file/d/13UOVRN-ujap_FK3vQE-vC8fff3YR4ZqK/

Demo: https://youtu.be/JVG441SJ7_w

New features:

Framerate text in white:
![image](https://user-images.githubusercontent.com/37698908/126751741-2e4e5fca-bccd-407c-a732-4d5f2efcc320.png)

Fixed fullscreen bug.
![image](https://user-images.githubusercontent.com/37698908/126747437-ff1d29df-4a36-4ca7-a6ae-f7492ff85c8c.png)

Smaller graph fonts:
![image](https://user-images.githubusercontent.com/37698908/126746517-36fd4232-172b-4828-a7d5-3bc1ec087ac4.png)

Draw lines and triangle before framerate plot:
![image](https://cdn.discordapp.com/attachments/353705816282628096/867821721490030622/unknown.png)

Center frametime:

![image](https://cdn.discordapp.com/attachments/353705816282628096/867831442041864212/unknown.png)

Fixes #96
Fixes #74
Fixes #36